### PR TITLE
Removed isort and factory-boy from install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,12 +86,10 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     install_requires=[
-        'isort',
         'jsonmask',
         'Django>=1.11',
         'djangorestframework>=3.5',
         'six',
-        'factory-boy'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
These are testing dependencies, and do not need to be installed along with a production installation of drf-partial-response.

Removing these dependencies is safe, as tox will install them during the tests (when they are needed)